### PR TITLE
Add Facebook sign up UI test

### DIFF
--- a/src/main/java/pages/FacebookHomePage.java
+++ b/src/main/java/pages/FacebookHomePage.java
@@ -1,0 +1,35 @@
+package pages;
+
+import data.Time;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import utils.LoggerUtils;
+
+public class FacebookHomePage extends CommonPageClass {
+
+    public FacebookHomePage(WebDriver driver) {
+        super(driver);
+    }
+
+    private final By createAccountButton = By.cssSelector("a[data-testid='open-registration-form-button']");
+
+    /**
+     * Opens the given url and waits for the page to be fully loaded.
+     * @param url URL of the facebook home page
+     * @return FacebookHomePage
+     */
+    public FacebookHomePage open(String url) {
+        LoggerUtils.log.debug("open(" + url + ")");
+        openUrl(url);
+        waitUntilPageIsReady(Time.TIME_SHORTER);
+        return this;
+    }
+
+    /**
+     * Clicks the "Create new account" button on the home page.
+     */
+    public void openCreateAccountForm() {
+        LoggerUtils.log.debug("openCreateAccountForm()");
+        click(createAccountButton, Time.TIME_SHORTER);
+    }
+}

--- a/src/main/java/pages/FacebookSignUpPage.java
+++ b/src/main/java/pages/FacebookSignUpPage.java
@@ -1,0 +1,83 @@
+package pages;
+
+import data.Time;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+import utils.LoggerUtils;
+
+import java.util.List;
+
+public class FacebookSignUpPage extends CommonPageClass {
+
+    public FacebookSignUpPage(WebDriver driver) {
+        super(driver);
+    }
+
+    private final By firstNameInput = By.name("firstname");
+    private final By lastNameInput = By.name("lastname");
+    private final By emailInput = By.name("reg_email__");
+    private final By emailConfirmationInput = By.name("reg_email_confirmation__");
+    private final By passwordInput = By.name("reg_passwd__");
+    private final By daySelect = By.id("day");
+    private final By monthSelect = By.id("month");
+    private final By yearSelect = By.id("year");
+    private final By genderRadioButtons = By.name("sex");
+    private final By signUpButton = By.name("websubmit");
+
+    public void enterFirstName(String firstName) {
+        LoggerUtils.log.debug("enterFirstName(" + firstName + ")");
+        WebElement element = getWebElement(firstNameInput, Time.TIME_SHORTER);
+        clearAndTypeTextToWebElement(element, firstName);
+    }
+
+    public void enterLastName(String lastName) {
+        LoggerUtils.log.debug("enterLastName(" + lastName + ")");
+        WebElement element = getWebElement(lastNameInput, Time.TIME_SHORTER);
+        clearAndTypeTextToWebElement(element, lastName);
+    }
+
+    public void enterEmail(String email) {
+        LoggerUtils.log.debug("enterEmail(" + email + ")");
+        WebElement element = getWebElement(emailInput, Time.TIME_SHORTER);
+        clearAndTypeTextToWebElement(element, email);
+    }
+
+    public void confirmEmail(String email) {
+        LoggerUtils.log.debug("confirmEmail(" + email + ")");
+        WebElement element = getWebElement(emailConfirmationInput, Time.TIME_SHORTER);
+        clearAndTypeTextToWebElement(element, email);
+    }
+
+    public void enterPassword(String password) {
+        LoggerUtils.log.debug("enterPassword(***)");
+        WebElement element = getWebElement(passwordInput, Time.TIME_SHORTER);
+        clearAndTypeTextToWebElement(element, password);
+    }
+
+    public void selectBirthDate(String day, String month, String year) {
+        LoggerUtils.log.debug("selectBirthDate(" + day + "," + month + "," + year + ")");
+        selectDropDownListOptionByText(getWebElement(daySelect, Time.TIME_SHORTER), day);
+        selectDropDownListOptionByText(getWebElement(monthSelect, Time.TIME_SHORTER), month);
+        selectDropDownListOptionByText(getWebElement(yearSelect, Time.TIME_SHORTER), year);
+    }
+
+    public void selectGender(String genderText) {
+        LoggerUtils.log.debug("selectGender(" + genderText + ")");
+        List<WebElement> radios = getWebElements(genderRadioButtons);
+        for (WebElement radio : radios) {
+            String label = radio.findElement(By.xpath("..//label")) != null ? radio.findElement(By.xpath("..//label")).getText() : "";
+            if (label.equalsIgnoreCase(genderText)) {
+                clickOnWebElement(radio);
+                break;
+            }
+        }
+    }
+
+    public void submitForm() {
+        LoggerUtils.log.debug("submitForm()");
+        WebElement button = getWebElement(signUpButton, Time.TIME_SHORTER);
+        clickOnWebElement(button);
+    }
+}

--- a/src/test/java/tests/UI/FacebookCreateAccountTest.java
+++ b/src/test/java/tests/UI/FacebookCreateAccountTest.java
@@ -1,0 +1,65 @@
+package tests.UI;
+
+import data.Time;
+import org.openqa.selenium.WebDriver;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import pages.FacebookHomePage;
+import pages.FacebookSignUpPage;
+import utils.DateTimeUtils;
+import utils.LoggerUtils;
+
+public class FacebookCreateAccountTest extends BaseTestClass {
+
+    private WebDriver driver;
+    private final String sTestName = this.getClass().getName();
+    private FacebookHomePage homePage;
+    private FacebookSignUpPage signUpPage;
+
+    @BeforeMethod
+    public void setUp(ITestContext testContext) {
+        LoggerUtils.log.debug("[SETUP TEST] " + sTestName);
+        driver = setUpMaxResolution();
+        testContext.setAttribute(sTestName + ".drivers", new WebDriver[]{driver});
+        homePage = new FacebookHomePage(driver);
+        signUpPage = new FacebookSignUpPage(driver);
+
+        String baseUrl = "https://www.facebook.com/";
+        homePage.open(baseUrl);
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        homePage.openCreateAccountForm();
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown(ITestResult result) {
+        LoggerUtils.log.debug("[END TEST] " + sTestName);
+        tearDown(driver, result);
+    }
+
+    @Test
+    public void testCreateAccountFlow() {
+        // Test data
+        String firstName = "John";
+        String lastName = "Doe";
+        String email = "johndoe@example.com";
+        String password = "Test@1234";
+        String birthDay = "10";
+        String birthMonth = "Jun";
+        String birthYear = "1990";
+        String gender = "Male";
+
+        signUpPage.enterFirstName(firstName);
+        signUpPage.enterLastName(lastName);
+        signUpPage.enterEmail(email);
+        signUpPage.confirmEmail(email);
+        signUpPage.enterPassword(password);
+        signUpPage.selectBirthDate(birthDay, birthMonth, birthYear);
+        signUpPage.selectGender(gender);
+        DateTimeUtils.wait(Time.TIME_DEMONSTRATION);
+        signUpPage.submitForm();
+    }
+}


### PR DESCRIPTION
## Summary
- add a FacebookHomePage with openCreateAccountForm
- add a FacebookSignUpPage with reusable entry methods
- create FacebookCreateAccountTest to run end-to-end sign-up flow

## Testing
- `mvn -q -Dtest=FacebookCreateAccountTest test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688a92d78f3c8323bf8313e799910d23